### PR TITLE
add authorization groups to certain routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ gem "lita-puppet"
 
 * Some of the commands require a [PuppetDB](https://docs.puppet.com/puppetdb/) server, and it must be specified in the configuration.
 * Other commands require that Lita has SSH access to machines using an SSH key, and that Lita has Passwordless `sudo` capabilities. This sounds scary, but it can be done in a very restrictive way (and if you're using puppet, you can automate it).
+* Lita authorization groups are used to restrict certain commands
 
 ## Configuration
 
@@ -37,6 +38,7 @@ If you are using this with version 4 of the PuppetDB api you append `/pdq/query`
 
 #### Deploying an environment via r10k
     puppet r10k [environment [module]]
+This requires the user is a member of the `puppet_admins` authorization group.
 
 This is also available as:
 
@@ -44,8 +46,10 @@ This is also available as:
     pp deploy [environment [module]]
     pp r10k [environment [module]]
 
+
 #### Trigger a manual run of the Puppet agent on a host
     puppet agent run on <host>
+This requires the user is a member of the `puppet_admins` authorization group.
 
 This is also available as:
 
@@ -59,6 +63,7 @@ Though we don't recomend that last one...
 
 #### Remove an SSL cert from the Puppet Master
     puppet cert clean <host>
+This requires the user is a member of the `puppet_admins` authorization group.
 
 This is also available as:
 

--- a/lib/lita/handlers/puppet.rb
+++ b/lib/lita/handlers/puppet.rb
@@ -14,6 +14,7 @@ module Lita
         /(puppet|pp)(\s+agent)?\s+(run)(\s+on)?\s+(\S+)/i,
         :puppet_agent_run,
         command: true,
+        restrict_to: :puppet_admins,
         help: { t('help.puppet_agent_run.syntax') => t('help.puppet_agent_run.desc') }
       )
 
@@ -21,6 +22,7 @@ module Lita
         /(puppet|pp)\s+(cert)\s+(clean)\s+(\S+)/i,
         :cert_clean,
         command: true,
+        restrict_to: :puppet_admins,
         help: { t('help.cert_clean.syntax') => t('help.cert_clean.desc') }
       )
 
@@ -42,6 +44,7 @@ module Lita
         /(puppet|pp)\s+(r10k|deploy)(\s+(\S+)(\s+(\S+))?)?/i,
         :r10k_deploy,
         command: true,
+        restrict_to: :puppet_admins,
         help: { t('help.r10k_deploy.syntax') => t('help.r10k_deploy.desc') }
       )
 

--- a/lita-puppet.gemspec
+++ b/lita-puppet.gemspec
@@ -1,7 +1,7 @@
 # rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
   spec.name          = 'lita-puppet'
-  spec.version       = '1.0.0'
+  spec.version       = '2.0.0'
   spec.authors       = ['Daniel Schaaff', 'Jonathan Gnagy'].sort
   spec.email         = ['jgnagy@knuedge.com']
   spec.description   = 'Some basic Puppet interactions for Lita'


### PR DESCRIPTION
membership in puppet_admins required for
- cleaning certs
- running the puppet agent on a node
- deploy using r10k

Bumped version to 2.0.0 due to breaking change

addresses #13 