### PR TITLE
handle error when there are no role or profile tags

### DIFF
--- a/lib/lita/handlers/puppet.rb
+++ b/lib/lita/handlers/puppet.rb
@@ -113,6 +113,8 @@ module Lita
 
         if profiles.is_a? String
           fail_message response, t('replies.node_profiles.failure', error: profiles)
+        elsif profiles == []
+          fail_message response, t('replies.node_profiles.failure_no_roles', host: host)
         else
           success_message(
             response,

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -37,6 +37,7 @@ en:
             notconf: "I would do that, but I don't know how to connect to PuppetDB. Edit my config and add `config.handlers.puppet.puppetdb_url`."
             working: "let me see what I can find in PuppetDB for you."
             failure: "Hmmm, that didn't work. Here's what PuppetDB responded with: '%{error}'"
+            failure_no_roles: "The catalog did not contain any roles or profiles for '%{host}'"
             success: "Here are the %{things} for %{host}:"
           nodes_with_class:
             notconf: "I would do that, but I don't know how to connect to PuppetDB. Edit my config and add `config.handlers.puppet.puppetdb_url`."

--- a/spec/lita/handlers/puppet_spec.rb
+++ b/spec/lita/handlers/puppet_spec.rb
@@ -128,6 +128,18 @@ describe Lita::Handlers::Puppet, lita_handler: true do
       send_command('puppet roles and profiles foo', as: lita_user)
       expect(replies.last).to eq("/code profile::foo\nrole::baz")
     end
+    it 'should return error for no profile or role tags' do
+      allow(::PuppetDB::Client).to receive(:get).and_return(
+        'resources' => {
+          'data' => [
+            { 'tags' => ['baz::foo'] },
+            { 'tags' => ['bar::baz'] }
+          ]
+        }
+      )
+      send_command('puppet roles and profiles foo', as: lita_user)
+      expect(replies.last).to eq("The catalog did not contain any roles or profiles for 'foo'")
+    end
   end
 
   describe('#nodes_with_class') do


### PR DESCRIPTION
Will resolve #16 _if_ the problem the user is getting a catalog back from puppetdb but it does not include any tags matching roles or profiles.