### PR TITLE
Truncating output and less broad error handling

### DIFF
--- a/lib/utils/lita_puppet/ssh.rb
+++ b/lib/utils/lita_puppet/ssh.rb
@@ -35,13 +35,12 @@ module Utils
         output = begin
           # pass our host back to the user to work with
           Timeout.timeout(opts[:timeout]) { yield remote }
-        rescue Rye::Err, StandardError => e
+        rescue Rye::Err, Timeout::Error => e
           exception = e
         ensure
           remote.disconnect
         end
 
-        remote = nil # Try to force the destruction of the Rye box
         calculate_result(output, exception)
       end
 

--- a/lib/utils/lita_puppet/text.rb
+++ b/lib/utils/lita_puppet/text.rb
@@ -36,6 +36,8 @@ module Utils
       def sanitze_for_chat(text)
         # Remove bash colorings
         text.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]/, '')
+        # Limit text to 50 lines
+        (text.lines.to_a[0...50] << "\n... truncated to 50 lines").join if text.lines.size > 50
       end
     end
   end

--- a/lib/utils/lita_puppet/text.rb
+++ b/lib/utils/lita_puppet/text.rb
@@ -35,9 +35,11 @@ module Utils
       # Strip off bad characters
       def sanitze_for_chat(text)
         # Remove bash colorings
-        text.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]/, '')
+        o = text.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]/, '')
         # Limit text to 50 lines
-        (text.lines.to_a[0...50] << "\n... truncated to 50 lines").join if text.lines.size > 50
+        o = (o.lines.to_a[0...49] << "\n... truncated to 50 lines").join if o.lines.size > 50
+        # return the output
+        o
       end
     end
   end

--- a/lita-puppet.gemspec
+++ b/lita-puppet.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-puppet'
-  spec.version       = '2.1.3'
+  spec.version       = '2.1.4'
   spec.authors       = ['Daniel Schaaff', 'Jonathan Gnagy'].sort
   spec.email         = ['jgnagy@knuedge.com']
   spec.description   = 'Some basic Puppet interactions for Lita'

--- a/spec/lita/handlers/puppet_spec.rb
+++ b/spec/lita/handlers/puppet_spec.rb
@@ -105,6 +105,10 @@ describe Lita::Handlers::Puppet, lita_handler: true do
   end
 
   describe('#puppet_agent_run') do
+    let(:rye_output_base) do
+      double(exit_status: 0, stdout: (0..99).to_a, stderr: ['bar'])
+    end
+
     before do
       robot.auth.add_user_to_group!(lita_user, :puppet_admins)
     end
@@ -112,6 +116,13 @@ describe Lita::Handlers::Puppet, lita_handler: true do
       allow(Rye::Box).to receive(:new).and_return(rye_box)
       send_command('puppet agent run on server.name', as: lita_user)
       expect(replies[-2]).to eq('that puppet run is complete! It exited with status 0.')
+    end
+
+    it 'should truncate long results' do
+      allow(Rye::Box).to receive(:new).and_return(rye_box)
+      send_command('puppet agent run on server.name', as: lita_user)
+      expect(replies[-1].lines.last).to eq('... truncated to 50 lines')
+      expect(replies[-1].lines.size).to eq(51)
     end
   end
 


### PR DESCRIPTION
Sometimes puppet output is very verbose. This should help suppress that.